### PR TITLE
Add space if prefix is unset, update time tests

### DIFF
--- a/src/ulog.c
+++ b/src/ulog.c
@@ -156,10 +156,13 @@ static void print_color_end(log_target *tgt, ulog_Event *ev) {
    Feature: Time
 ============================================================================ */
 #if FEATURE_TIME
+#define TIME_STAMP_BUF_SIZE 10
+#define FULL_TIME_STAMP_BUF_SIZE 21
+
 
 static void print_time_sec(log_target *tgt, ulog_Event *ev) {
 
-    char buf[10];
+    char buf[TIME_STAMP_BUF_SIZE];
 #if FEATURE_CUSTOM_PREFIX
     // If the custom prefix function is not set, add a space after the time
     if(!ulog.update_prefix_function) {
@@ -177,7 +180,7 @@ static void print_time_sec(log_target *tgt, ulog_Event *ev) {
 #if FEATURE_EXTRA_OUTPUTS
 static void print_time_full(log_target *tgt, ulog_Event *ev) {
     
-    char buf[21];
+    char buf[FULL_TIME_STAMP_BUF_SIZE];
 #if FEATURE_CUSTOM_PREFIX
     // If the custom prefix function is not set, add a space after the time
     if(!ulog.update_prefix_function) {

--- a/src/ulog.c
+++ b/src/ulog.c
@@ -159,11 +159,15 @@ static void print_color_end(log_target *tgt, ulog_Event *ev) {
 
 static void print_time_sec(log_target *tgt, ulog_Event *ev) {
 
-#if FEATURE_CUSTOM_PREFIX
-    char buf[9];
-    buf[strftime(buf, sizeof(buf), "%H:%M:%S", ev->time)] = '\0';
-#else   // FEATURE_CUSTOM_PREFIX
     char buf[10];
+#if FEATURE_CUSTOM_PREFIX
+    // If the custom prefix function is not set, add a space after the time
+    if(!ulog.update_prefix_function) {
+        buf[strftime(buf, sizeof(buf), "%H:%M:%S ", ev->time)] = '\0';
+    } else {
+        buf[strftime(buf, sizeof(buf)-1, "%H:%M:%S", ev->time)] = '\0';
+    }
+#else   // FEATURE_CUSTOM_PREFIX
     buf[strftime(buf, sizeof(buf), "%H:%M:%S ", ev->time)] = '\0';
 #endif  // FEATURE_CUSTOM_PREFIX
 
@@ -172,12 +176,16 @@ static void print_time_sec(log_target *tgt, ulog_Event *ev) {
 
 #if FEATURE_EXTRA_OUTPUTS
 static void print_time_full(log_target *tgt, ulog_Event *ev) {
-
+    
+    char buf[21];
 #if FEATURE_CUSTOM_PREFIX
-    char buf[64];
-    buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ev->time)] = '\0';
+    // If the custom prefix function is not set, add a space after the time
+    if(!ulog.update_prefix_function) {
+        buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S ", ev->time)] = '\0';
+    } else {
+        buf[strftime(buf, sizeof(buf)-1, "%Y-%m-%d %H:%M:%S", ev->time)] = '\0';
+    }
 #else   // FEATURE_CUSTOM_PREFIX
-    char buf[65];
     buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S ", ev->time)] = '\0';
 #endif  // FEATURE_CUSTOM_PREFIX
 

--- a/tests/unit/test_time.cpp
+++ b/tests/unit/test_time.cpp
@@ -11,6 +11,8 @@ constexpr static size_t FULL_TIME_STAMP_SIZE = 19;  // YYYY-MM-DD HH:MM:SS
 #if FEATURE_CUSTOM_PREFIX
 static void test_prefix(ulog_Event *ev, char *prefix, size_t prefix_size) {
     (void)ev;
+
+    // NOTE: Test cases expect the first character to be non-whitespace
     snprintf(prefix, prefix_size, "[PREFIX]");
 }
 #endif  // FEATURE_CUSTOM_PREFIX
@@ -83,7 +85,7 @@ void _check_console_time(bool prefix = false) {
 #if FEATURE_CUSTOM_PREFIX
     if (prefix) {
         // Should be no space after time
-        REQUIRE(ut_callback_get_last_message()[TIME_STAMP_SIZE] == '[');
+        REQUIRE(ut_callback_get_last_message()[TIME_STAMP_SIZE] != ' ');
     } else {
         // If no custom prefix, there should be a space after the time
         REQUIRE(ut_callback_get_last_message()[TIME_STAMP_SIZE] == ' ');
@@ -98,12 +100,12 @@ void _check_console_time(bool prefix = false) {
 
 void _check_file_time(bool prefix = false) {
     std::string filename;
-    if (prefix) 
+    if (prefix)
         filename = "test_output_prefix.log";
     else
-        filename = "test_output_np.log";
+        filename = "test_output_no_prefix.log";
 
-    FILE *fp             = fopen(filename.c_str(), "w");
+    FILE *fp = fopen(filename.c_str(), "w");
     REQUIRE(fp != nullptr);
     ulog_add_fp(fp, LOG_INFO);
 
@@ -123,14 +125,13 @@ void _check_file_time(bool prefix = false) {
 
     // Parse time values, ensure 6 matches
     int yr, mo, d, hh, mm, ss;
-    log_debug("Last message: %s", buffer);
     REQUIRE(sscanf(buffer, "%d-%d-%d %d:%d:%d ", &yr, &mo, &d, &hh, &mm, &ss) ==
             6);
 
 #if FEATURE_CUSTOM_PREFIX
     if (prefix) {
         // Should be no space after time
-        REQUIRE(buffer[FULL_TIME_STAMP_SIZE] == '[');
+        REQUIRE(buffer[FULL_TIME_STAMP_SIZE] != ' ');
     } else {
         // If no custom prefix, there should be a space after the time
         REQUIRE(buffer[FULL_TIME_STAMP_SIZE] == ' ');

--- a/tests/unit/test_time.cpp
+++ b/tests/unit/test_time.cpp
@@ -5,7 +5,8 @@
 #include "ulog.h"
 #include "ut_callback.h"
 
-constexpr static size_t TIME_STAMP_SIZE = 8;  // HH:MM:SS
+constexpr static size_t TIME_STAMP_SIZE      = 8;   // HH:MM:SS
+constexpr static size_t FULL_TIME_STAMP_SIZE = 19;  // YYYY-MM-DD HH:MM:SS
 
 #if FEATURE_CUSTOM_PREFIX
 static void test_prefix(ulog_Event *ev, char *prefix, size_t prefix_size) {
@@ -67,7 +68,7 @@ static void _check_date_time_fields(int yr, int mo, int d, int hh, int mm,
     CHECK_LE(d, after_tm->tm_mday);
 }
 
-void _check_console_time() {
+void _check_console_time(bool prefix = false) {
     time_t before, after;
     _get_time_bounds(before, after);
 
@@ -79,10 +80,14 @@ void _check_console_time() {
     REQUIRE(sscanf(ut_callback_get_last_message(), "%d:%d:%d ", &hh, &mm,
                    &ss) == 3);
 
-    printf("Last message: %s\n", ut_callback_get_last_message());
 #if FEATURE_CUSTOM_PREFIX
-    // Should be no space after time
-    REQUIRE(ut_callback_get_last_message()[TIME_STAMP_SIZE] != ' ');
+    if (prefix) {
+        // Should be no space after time
+        REQUIRE(ut_callback_get_last_message()[TIME_STAMP_SIZE] == '[');
+    } else {
+        // If no custom prefix, there should be a space after the time
+        REQUIRE(ut_callback_get_last_message()[TIME_STAMP_SIZE] == ' ');
+    }
 #else   // FEATURE_CUSTOM_PREFIX
     // If no custom prefix, there should be a space after the time
     REQUIRE(ut_callback_get_last_message()[TIME_STAMP_SIZE] == ' ');
@@ -91,9 +96,14 @@ void _check_console_time() {
     _check_time_fields(hh, mm, ss, before, after);
 }
 
-void _check_file_time() {
-    const char *filename = "test_output.log";
-    FILE *fp             = fopen(filename, "w");
+void _check_file_time(bool prefix = false) {
+    std::string filename;
+    if (prefix) 
+        filename = "test_output_prefix.log";
+    else
+        filename = "test_output_np.log";
+
+    FILE *fp             = fopen(filename.c_str(), "w");
     REQUIRE(fp != nullptr);
     ulog_add_fp(fp, LOG_INFO);
 
@@ -103,7 +113,7 @@ void _check_file_time() {
     fclose(fp);
 
     // Check if the file was created
-    fp = fopen(filename, "r");
+    fp = fopen(filename.c_str(), "r");
     REQUIRE(fp != nullptr);
 
     // Read entry
@@ -113,8 +123,22 @@ void _check_file_time() {
 
     // Parse time values, ensure 6 matches
     int yr, mo, d, hh, mm, ss;
+    log_debug("Last message: %s", buffer);
     REQUIRE(sscanf(buffer, "%d-%d-%d %d:%d:%d ", &yr, &mo, &d, &hh, &mm, &ss) ==
             6);
+
+#if FEATURE_CUSTOM_PREFIX
+    if (prefix) {
+        // Should be no space after time
+        REQUIRE(buffer[FULL_TIME_STAMP_SIZE] == '[');
+    } else {
+        // If no custom prefix, there should be a space after the time
+        REQUIRE(buffer[FULL_TIME_STAMP_SIZE] == ' ');
+    }
+#else   // FEATURE_CUSTOM_PREFIX
+    // If no custom prefix, there should be a space after the time
+    REQUIRE(buffer[FULL_TIME_STAMP_SIZE] == ' ');
+#endif  // FEATURE_CUSTOM_PREFIX
 
     _check_date_time_fields(yr, mo, d, hh, mm, ss, before, after);
 }
@@ -128,7 +152,7 @@ TEST_CASE_FIXTURE(TimeTestFixture, "Check time without prefix") {
 TEST_CASE_FIXTURE(TimeTestFixture, "Check time with prefix") {
     ulog_set_prefix_fn(test_prefix);
 
-    _check_console_time();
-    _check_file_time();
+    _check_console_time(true);
+    _check_file_time(true);
 }
 #endif  // FEATURE_CUSTOM_PREFIX


### PR DESCRIPTION
* Check if prefix function is set when printing time string and add a space if not.
* Reduce buffer size on `print_time_full`
* Update `test_time.cpp`