### PR TITLE
Adds CPM option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ exe = executable(
 )
 ```
 
+**Option 4 - CPM:**
+
+- Download CPM (https://github.com/cpm-cmake/CPM.cmake)
+- Add microlog to your projects CMAKE file:
+```cmake
+include(cpm/CPM.cmake)
+CPMAddPackage("gh:an-dr/microlog@6.4.5")
+#Add other CPM packages
+
+target_link_libraries(${PROJECT_NAME} PUBLIC microlog)
+target_compile_definitions( microlog
+        INTERFACE
+        ULOG_NO_COLOR) # configuration
+```
+
 ### Use
 
 ```cpp


### PR DESCRIPTION
Documents a new installation option using CPM for ease of use. Includes instructions for integrating microlog with the users project CMAKELists.txt file.

ftr: I use microlog in this manner and it works great, my own lib (https://github.com/JeroenVandezande/LowLevelCPPClasses) pulls in microlog in that way.
