### PR TITLE
fix: return ULOG_NO_COLOR instead of ULOG_HAVE_COLOR (#99)

### DIFF
--- a/include/ulog.h
+++ b/include/ulog.h
@@ -44,10 +44,10 @@ extern "C" {
 
 ============================================================================ */
 // clang-format off
-#ifdef ULOG_HAVE_COLOR
-    #define ULOG_FEATURE_COLOR true
-#else
+#ifdef ULOG_NO_COLOR
     #define ULOG_FEATURE_COLOR false
+#else
+    #define ULOG_FEATURE_COLOR true
 #endif
 
 


### PR DESCRIPTION
Fixes issue #99 by replacing `ULOG_HAVE_COLOR` with `ULOG_NO_COLOR` in the color feature check, ensuring correct behavior when color output is disabled.