### PR TITLE
Add `ulog_output_level_get()` and `ulog_topic_level_get()`

### DIFF
--- a/doc/features.md
+++ b/doc/features.md
@@ -168,6 +168,15 @@ In this case the stdout-printed line will be:
 INFO  src/main.c:66: Info message 3.000000
 ```
 
+The current log level of an output can be acquired using the `ulog_output_level_get(ulog_output_id output, ulog_level *level)` function:
+
+```c
+ulog_level lvl;
+ulog_output_level_get(ULOG_OUTPUT_STDOUT, &lvl);
+
+printf("loglevel: %s\n", ulog_level_to_string(lvl));
+```
+
 ### Events
 
 The events care information depending on the static configuration. The whole list of possible data:
@@ -280,6 +289,7 @@ When the feature is enabled all logging macros are replaced with empty stubs or 
 | ulog_log                    | `(void)0`                  |
 | ulog_output_add             | `ULOG_OUTPUT_INVALID`      |
 | ulog_output_add_file        | `ULOG_OUTPUT_INVALID`      |
+| ulog_output_level_get       | `ULOG_STATUS_DISABLED`     |
 | ulog_output_level_set       | `ULOG_STATUS_DISABLED`     |
 | ulog_output_level_set_all   | `ULOG_STATUS_DISABLED`     |
 | ulog_output_remove          | `ULOG_STATUS_DISABLED`     |
@@ -290,6 +300,7 @@ When the feature is enabled all logging macros are replaced with empty stubs or 
 | ulog_topic_add              | `ULOG_TOPIC_ID_INVALID`    |
 | ulog_topic_config           | `ULOG_STATUS_DISABLED`     |
 | ulog_topic_get_id           | `ULOG_TOPIC_ID_INVALID`    |
+| ulog_topic_level_get        | `ULOG_STATUS_DISABLED`     |
 | ulog_topic_level_set        | `ULOG_STATUS_DISABLED`     |
 | ulog_topic_remove           | `ULOG_STATUS_DISABLED`     |
 
@@ -416,6 +427,15 @@ ulog_topic_level_set("storage", ULOG_LEVEL_WARN); // Storage is set to WARN
 ulog_topic_info("storage", "No free space"); // generated
 ulog_topic_info("network", "Connected to server"); // filtered out topic
 ulog_topic_debug("storage", "No free space"); // filtered out level DEBUG < INFO
+```
+
+The current loglevel of each topic can be acquired using the `ulog_topic_level_get()` function:
+
+```c
+ulog_level lvl;
+ulog_topic_level_get("network", &lvl);
+
+printf("network loglevel: %s\n", ulog_level_to_string(lvl));
 ```
 
 Topics can be removed by using the `ulog_topic_remove()` function.

--- a/include/ulog.h
+++ b/include/ulog.h
@@ -272,6 +272,13 @@ typedef void (*ulog_output_handler_fn)(ulog_event *ev, void *arg);
 
 #if ULOG_BUILD_DISABLED != 1
 
+/// @brief Gets the current log level for a specific output
+/// @param output Output handle to configure
+/// @param level Current log level for this output will be stored here
+/// @return ULOG_STATUS_OK on success, ULOG_STATUS_INVALID_ARGUMENT if invalid
+///         parameters, ULOG_STATUS_NOT_FOUND if output not found
+ulog_status ulog_output_level_get(ulog_output_id output, ulog_level *out_level);
+
 /// @brief Sets the minimum log level for a specific output
 /// @param output Output handle to configure
 /// @param level Minimum log level for this output
@@ -389,6 +396,13 @@ ulog_topic_id ulog_topic_add(const char *topic_name, ulog_output_id output,
 /// @return ULOG_STATUS_OK on success, ULOG_STATUS_NOT_FOUND if topic not found
 ulog_status ulog_topic_remove(const char *topic_name);
 
+/// @brief Gets the current log level for a topic  (requires
+/// ULOG_BUILD_TOPICS!=0 or ULOG_BUILD_DYNAMIC_CONFIG=1)
+/// @param topic_name Topic name string (empty or NULL names are invalid)
+/// @param level Current log level for this topic will be stored here
+/// @return ULOG_STATUS_OK on success, ULOG_STATUS_NOT_FOUND if topic not found
+ulog_status ulog_topic_level_get(const char *topic_name, ulog_level *level);
+
 /// @brief Sets the minimum log level for a topic  (requires
 /// ULOG_BUILD_TOPICS!=0 or ULOG_BUILD_DYNAMIC_CONFIG=1)
 /// @param topic_name Topic name string (empty or NULL names are invalid)
@@ -449,7 +463,7 @@ ulog_topic_id ulog_topic_get_id(const char *topic_name);
 /// @param ... Format arguments for the message
 void ulog_log(ulog_level level, const char *file,
               int line, const char *topic, const char *message, ...);
-              
+
 
 /// @brief Clean up all topic, outputs and other dynamic resources
 ulog_status ulog_cleanup(void);
@@ -474,91 +488,97 @@ ulog_status ulog_cleanup(void);
 #endif
 
 // clang-format off
-ULOG_STATIC_INLINE ulog_status ulog_cleanup(void) 
+ULOG_STATIC_INLINE ulog_status ulog_cleanup(void)
     { return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_color_config(bool enabled) 
+
+ULOG_STATIC_INLINE ulog_status ulog_color_config(bool enabled)
     { (void)enabled; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE const char* ulog_event_get_file(ulog_event *ev) 
+
+ULOG_STATIC_INLINE const char* ulog_event_get_file(ulog_event *ev)
     { (void)ev; return ""; }
-    
-ULOG_STATIC_INLINE ulog_level ulog_event_get_level(ulog_event *ev) 
+
+ULOG_STATIC_INLINE ulog_level ulog_event_get_level(ulog_event *ev)
     { (void)ev; return ULOG_LEVEL_0; }
-    
-ULOG_STATIC_INLINE int ulog_event_get_line(ulog_event *ev) 
+
+ULOG_STATIC_INLINE int ulog_event_get_line(ulog_event *ev)
     { (void)ev; return -1; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_event_get_message(ulog_event *ev, char *buffer, size_t buffer_size) 
+
+ULOG_STATIC_INLINE ulog_status ulog_event_get_message(ulog_event *ev, char *buffer, size_t buffer_size)
     { (void)ev; (void)buffer; (void)buffer_size; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE struct tm* ulog_event_get_time(ulog_event *ev) 
+
+ULOG_STATIC_INLINE struct tm* ulog_event_get_time(ulog_event *ev)
     { (void)ev; return NULL; }
-    
-ULOG_STATIC_INLINE ulog_topic_id ulog_event_get_topic(ulog_event *ev) 
+
+ULOG_STATIC_INLINE ulog_topic_id ulog_event_get_topic(ulog_event *ev)
     { (void)ev; return ULOG_TOPIC_ID_INVALID; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_event_to_cstr(ulog_event *ev, char *out, size_t out_size) 
+
+ULOG_STATIC_INLINE ulog_status ulog_event_to_cstr(ulog_event *ev, char *out, size_t out_size)
     { (void)ev; (void)out; (void)out_size; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_level_config(ulog_level_config_style style) 
+
+ULOG_STATIC_INLINE ulog_status ulog_level_config(ulog_level_config_style style)
     { (void)style; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_level_reset_levels(void) 
+
+ULOG_STATIC_INLINE ulog_status ulog_level_reset_levels(void)
     { return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_level_set_new_levels(const ulog_level_descriptor *new_levels) 
+
+ULOG_STATIC_INLINE ulog_status ulog_level_set_new_levels(const ulog_level_descriptor *new_levels)
     { (void)new_levels; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE const char* ulog_level_to_string(ulog_level level) 
+
+ULOG_STATIC_INLINE const char* ulog_level_to_string(ulog_level level)
     { (void)level; return "?"; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_lock_set_fn(ulog_lock_fn function, void *lock_arg) 
+
+ULOG_STATIC_INLINE ulog_status ulog_lock_set_fn(ulog_lock_fn function, void *lock_arg)
     { (void)function; (void)lock_arg; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE void ulog_log(ulog_level level, const char *file, int line, const char *topic, const char *message, ...) 
+
+ULOG_STATIC_INLINE void ulog_log(ulog_level level, const char *file, int line, const char *topic, const char *message, ...)
     { (void)level; (void)file; (void)line; (void)topic; (void)message; }
-    
-ULOG_STATIC_INLINE ulog_output_id ulog_output_add(ulog_output_handler_fn handler, void *arg, ulog_level level) 
+
+ULOG_STATIC_INLINE ulog_output_id ulog_output_add(ulog_output_handler_fn handler, void *arg, ulog_level level)
     { (void)handler; (void)arg; (void)level; return ULOG_OUTPUT_INVALID; }
-    
-ULOG_STATIC_INLINE ulog_output_id ulog_output_add_file(FILE *file, ulog_level level) 
+
+ULOG_STATIC_INLINE ulog_output_id ulog_output_add_file(FILE *file, ulog_level level)
     { (void)file; (void)level; return ULOG_OUTPUT_INVALID; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_output_level_set(ulog_output_id output, ulog_level level) 
+
+ULOG_STATIC_INLINE ulog_status ulog_output_level_get(ulog_output_id output, ulog_level *level)
     { (void)output; (void)level; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_output_level_set_all(ulog_level level) 
+
+ULOG_STATIC_INLINE ulog_status ulog_output_level_set(ulog_output_id output, ulog_level level)
+    { (void)output; (void)level; return ULOG_STATUS_DISABLED; }
+
+ULOG_STATIC_INLINE ulog_status ulog_output_level_set_all(ulog_level level)
     { (void)level; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_output_remove(ulog_output_id output) 
+
+ULOG_STATIC_INLINE ulog_status ulog_output_remove(ulog_output_id output)
     { (void)output; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_prefix_config(bool enabled) 
+
+ULOG_STATIC_INLINE ulog_status ulog_prefix_config(bool enabled)
     { (void)enabled; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_prefix_set_fn(ulog_prefix_fn function) 
+
+ULOG_STATIC_INLINE ulog_status ulog_prefix_set_fn(ulog_prefix_fn function)
     { (void)function; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_source_location_config(bool enabled) 
+
+ULOG_STATIC_INLINE ulog_status ulog_source_location_config(bool enabled)
     { (void)enabled; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_time_config(bool enabled) 
+
+ULOG_STATIC_INLINE ulog_status ulog_time_config(bool enabled)
     { (void)enabled; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_topic_id ulog_topic_add(const char *topic_name, ulog_output_id output, ulog_level level) 
+
+ULOG_STATIC_INLINE ulog_topic_id ulog_topic_add(const char *topic_name, ulog_output_id output, ulog_level level)
     { (void)topic_name; (void)output; (void)level; return ULOG_TOPIC_ID_INVALID; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_topic_config(bool enabled) 
+
+ULOG_STATIC_INLINE ulog_status ulog_topic_config(bool enabled)
     { (void)enabled; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_topic_id ulog_topic_get_id(const char *topic_name) 
+
+ULOG_STATIC_INLINE ulog_topic_id ulog_topic_get_id(const char *topic_name)
     { (void)topic_name; return ULOG_TOPIC_ID_INVALID; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_topic_level_set(const char *topic_name, ulog_level level) 
+
+ULOG_STATIC_INLINE ulog_status ulog_topic_level_set(const char *topic_name, ulog_level level)
     { (void)topic_name; (void)level; return ULOG_STATUS_DISABLED; }
-    
-ULOG_STATIC_INLINE ulog_status ulog_topic_remove(const char *topic_name) 
+
+ULOG_STATIC_INLINE ulog_status ulog_topic_level_get(const char *topic_name, ulog_level *level)
+    { (void)topic_name; (void)level; return ULOG_STATUS_DISABLED; }
+
+ULOG_STATIC_INLINE ulog_status ulog_topic_remove(const char *topic_name)
     { (void)topic_name; return ULOG_STATUS_DISABLED; }
 
 #define ulog_trace(...) ((void)0)

--- a/src/ulog.c
+++ b/src/ulog.c
@@ -985,6 +985,18 @@ static void output_stdout_handler(ulog_event *ev, void *arg) {
 // Public
 // ================
 
+ulog_status ulog_output_level_get(ulog_output_id output, ulog_level *out_level) {
+    if (output < ULOG_OUTPUT_STDOUT || output >= OUTPUT_TOTAL_NUM || out_level == NULL) {
+        return ULOG_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (output_data.outputs[output].handler == NULL) {
+        return ULOG_STATUS_NOT_FOUND;  // Output exists but no handler assigned
+    }
+    *out_level = output_data.outputs[output].level;
+    return ULOG_STATUS_OK;
+}
+
 ulog_status ulog_output_level_set(ulog_output_id output, ulog_level level) {
     if (!level_is_valid(level)) {
         return ULOG_STATUS_INVALID_ARGUMENT;
@@ -1249,6 +1261,19 @@ static void topic_print(print_target *tgt, ulog_event *ev) {
     }
 }
 
+/// @brief Get the topic level
+/// @param topic - Topic ID
+/// @param level - Current log level will be stored here
+/// @return ULOG_STATUS_OK if success, ULOG_STATUS_NOT_FOUND if topic not found
+static ulog_status topic_get_level(int topic, ulog_level *level) {
+    topic_t *t = topic_get(topic);
+    if (t != NULL) {
+        *level = t->level;
+        return ULOG_STATUS_OK;
+    }
+    return ULOG_STATUS_NOT_FOUND;
+}
+
 /// @brief Sets the topic level
 /// @param topic - Topic ID
 /// @param level - Log level to set
@@ -1313,6 +1338,17 @@ ulog_status ulog_topic_level_set(const char *topic_name, ulog_level level) {
     return topic_set_level(topic_id, level);
 }
 
+ulog_status ulog_topic_level_get(const char *topic_name, ulog_level *level) {
+    ulog_topic_id topic_id = ulog_topic_get_id(topic_name);
+    if (topic_id == ULOG_TOPIC_ID_INVALID) {
+        return ULOG_STATUS_NOT_FOUND;  // Topic not found, do nothing
+    }
+    if (level == NULL) {
+        return ULOG_STATUS_INVALID_ARGUMENT;
+    }
+    return topic_get_level(topic_id, level);
+}
+
 ulog_topic_id ulog_topic_get_id(const char *topic_name) {
     return topic_str_to_id(topic_name);
 }
@@ -1344,6 +1380,13 @@ ulog_status ulog_topic_remove(const char *topic_name) {
 #if ULOG_HAS_WARN_NOT_ENABLED
 
 ulog_status ulog_topic_level_set(const char *topic_name, ulog_level level) {
+    (void)(topic_name);
+    (void)(level);
+    warn_not_enabled("ULOG_BUILD_TOPICS_MODE");
+    return ULOG_STATUS_DISABLED;
+}
+
+ulog_status ulog_topic_level_get(const char *topic_name, ulog_level *level) {
     (void)(topic_name);
     (void)(level);
     warn_not_enabled("ULOG_BUILD_TOPICS_MODE");

--- a/tests/unit/test_output.cpp
+++ b/tests/unit/test_output.cpp
@@ -128,6 +128,23 @@ TEST_CASE_FIXTURE(OutputTestFixture, "Output Level Set Specific") {
     }
 }
 
+TEST_CASE_FIXTURE(OutputTestFixture, "Output Level Get Specific") {
+	SUBCASE("Get stdout level") {
+            ulog_level level;
+            ulog_status result = ulog_output_level_set(ULOG_OUTPUT_STDOUT, ULOG_LEVEL_TRACE);
+            CHECK(result == ULOG_STATUS_OK);
+            result = ulog_output_level_get(ULOG_OUTPUT_STDOUT, &level);
+            CHECK(result == ULOG_STATUS_OK);
+            CHECK(level == ULOG_LEVEL_TRACE);
+
+            result = ulog_output_level_set(ULOG_OUTPUT_STDOUT, ULOG_LEVEL_WARN);
+            CHECK(result == ULOG_STATUS_OK);
+            result = ulog_output_level_get(ULOG_OUTPUT_STDOUT, &level);
+            CHECK(result == ULOG_STATUS_OK);
+            CHECK(level == ULOG_LEVEL_WARN);
+        }
+}
+
 TEST_CASE_FIXTURE(OutputTestFixture, "Output Add Custom Handler") {
     SUBCASE("Add valid custom handler") {
         int test_arg = 42;

--- a/tests/unit/test_topics.cpp
+++ b/tests/unit/test_topics.cpp
@@ -48,6 +48,27 @@ TEST_CASE_FIXTURE(TestFixture, "Topics: Levels") {
     CHECK(ut_callback_get_message_count() == 5);
 }
 
+TEST_CASE_FIXTURE(TestFixture, "Topics: Get Level") {
+    ulog_level level;
+    ulog_status result;
+
+    ulog_topic_add("topic", ULOG_OUTPUT_ALL, ULOG_LEVEL_TRACE);
+
+    result = ulog_topic_level_set("topic", ULOG_LEVEL_TRACE);
+    CHECK(result == ULOG_STATUS_OK);
+    result = ulog_topic_level_get("topic", &level);
+    CHECK(result == ULOG_STATUS_OK);
+    CHECK(level == ULOG_LEVEL_TRACE);
+
+    result = ulog_topic_level_set("topic", ULOG_LEVEL_WARN);
+    CHECK(result == ULOG_STATUS_OK);
+    result = ulog_topic_level_get("topic", &level);
+    CHECK(result == ULOG_STATUS_OK);
+    CHECK(level == ULOG_LEVEL_WARN);
+
+    ulog_topic_remove("topic");
+}
+
 TEST_CASE_FIXTURE(TestFixture, "Topics: Cannot create topic with empty name") {
     int res;
 


### PR DESCRIPTION
Currently there is no way to acquire the currently configured loglevel from a single source of truth.

This provides getters for output and topic loglevels to applications.

(also removes trailing whitespace according to style.md)