### PR TITLE
Fix maximum level string lookup

### DIFF
--- a/src/ulog.c
+++ b/src/ulog.c
@@ -864,7 +864,7 @@ static void level_print(print_target *tgt, ulog_event *ev) {
 
 /// @brief Returns the string representation of the level
 const char *ulog_level_to_string(ulog_level level) {
-    if (level < LEVEL_MIN_VALUE || level >= level_data.dsc->max_level) {
+    if (level < LEVEL_MIN_VALUE || level > level_data.dsc->max_level) {
         return "?";  // Return a default string for invalid levels
     }
 

--- a/tests/unit/test_core.cpp
+++ b/tests/unit/test_core.cpp
@@ -106,3 +106,7 @@ TEST_CASE_FIXTURE(TestFixture, "Invalid Level Handling") {
     result = ulog_level_set_new_levels(&invalid_max_desc);
     CHECK(result == ULOG_STATUS_INVALID_ARGUMENT);
 }
+
+TEST_CASE_FIXTURE(TestFixture, "Maximum Level String") {
+    CHECK(strcmp(ulog_level_to_string(ULOG_LEVEL_FATAL), "FATAL") == 0);
+}


### PR DESCRIPTION
## Summary

- Treat max_level as an inclusive boundary in ulog_level_to_string().
- Add a regression test for the default FATAL level.

## Problem

Level descriptors and level_is_valid() both treat max_level as the final valid entry. The string conversion used a greater-than-or-equal check, so the configured maximum returned ? instead of its name. This affected the default FATAL level and the maximum entry of custom descriptors such as syslog EMERG.

## Validation

- MinGW CMake build and full CTest suite: 16/16 passed
- CoreTests with -Wall -Wextra -Werror
- Baseline/fixed checks for the default and syslog maximum levels